### PR TITLE
Update and align code style in empty line usage and test cases

### DIFF
--- a/src/rules/NoIgnoredReturnRule.ts
+++ b/src/rules/NoIgnoredReturnRule.ts
@@ -218,6 +218,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
             const methods = this.METHODS_WITHOUT_SIDE_EFFECTS[typeAsString];
             return methods && methods.has(methodName);
         }
+
         return false;
     }
 
@@ -240,7 +241,6 @@ class Walker extends Lint.ProgramAwareRuleWalker {
         }
 
         return null;
-
     }
 
     private isReplaceWithCallBack(methodName: string, callArguments: ts.NodeArray<ts.Expression>): boolean {

--- a/tests/rules/NoIdenticalExpressionsRule/NoIdenticalExpressionsRule.test.ts
+++ b/tests/rules/NoIdenticalExpressionsRule/NoIdenticalExpressionsRule.test.ts
@@ -1,11 +1,11 @@
 import { Rule } from "../../../src/rules/NoIdenticalExpressionsRule";
 import { runRule, runRuleOnRuling } from "../../runRule";
 
-it("raises error", () => {
+it("unit test", () => {
   const { actualErrors, expectedErrors } = runRule(Rule, __filename);
   expect(actualErrors).toEqual(expectedErrors);
 });
 
-it("ruling", () => {
+it("ruling test", () => {
   expect(runRuleOnRuling(Rule)).toMatchSnapshot();
 });

--- a/tests/rules/NoIgnoredReturnRule/NoIgnoredReturnRule.test.ts
+++ b/tests/rules/NoIgnoredReturnRule/NoIgnoredReturnRule.test.ts
@@ -2,8 +2,8 @@ import { Rule } from "../../../src/rules/NoIgnoredReturnRule";
 import { runRule, runRuleOnRuling } from "../../runRule";
 
 it("test", () => {
-  const result = runRule(Rule, __filename);
-  expect(result.actualErrors).toEqual(result.expectedErrors);
+  const { actualErrors, expectedErrors } = runRule(Rule, __filename);
+  expect(actualErrors).toEqual(expectedErrors);
 });
 
 it("ruling", () => {

--- a/tests/rules/NoIgnoredReturnRule/NoIgnoredReturnRule.test.ts
+++ b/tests/rules/NoIgnoredReturnRule/NoIgnoredReturnRule.test.ts
@@ -1,11 +1,11 @@
 import { Rule } from "../../../src/rules/NoIgnoredReturnRule";
 import { runRule, runRuleOnRuling } from "../../runRule";
 
-it("test", () => {
+it("unit test", () => {
   const { actualErrors, expectedErrors } = runRule(Rule, __filename);
   expect(actualErrors).toEqual(expectedErrors);
 });
 
-it("ruling", () => {
+it("ruling test", () => {
   expect(runRuleOnRuling(Rule)).toMatchSnapshot();
 });

--- a/tests/runRule.ts
+++ b/tests/runRule.ts
@@ -55,6 +55,7 @@ export function runRule(Rule: any, testFileName: string): RuleRunResult {
   const source = fs.readFileSync(lintFileName, "utf-8");
   const actualErrors = runRuleOnFile(Rule, lintFileName);
   const expectedErrors = parseErrorsFromMarkup(source);
+
   return { actualErrors, expectedErrors };
 }
 
@@ -65,6 +66,7 @@ export function runRuleOnRuling(Rule: any): string[] {
 
   tsconfigFiles.sort();
   tsconfigFiles.forEach((tsconfigFileName: string) => runRuleOnProject(Rule, tsconfigFileName, snapshot));
+
   return snapshot;
 }
 
@@ -163,5 +165,6 @@ function lineNumberedFromOne(lineNumberedFromZero: number) {
 function getFileNameForSnapshot(path: string) {
   const marker = "/typescript-test-sources/";
   const pos = path.indexOf(marker);
+
   return path.substr(pos + marker.length);
 }


### PR DESCRIPTION
In order to keep a consistent style, every multi-line functions should contain one empty line before the return statement, and no other lines after that.