### PR TITLE
partial fix to header check configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
   "license-check-config": {
     "src": [
       "src/**/*.ts",
-      "tests/rules/**/*.test.ts",
-      "tests/ruling/**/*.ts",
-      "!./node_modules/**/*"
+      "tests/**/*.ts",
+      "!tests/**/*.lint.ts",
+      "!node_modules/**/*"
     ],
     "path": "HEADER",
     "blocking": true,

--- a/tests/cfg/cfg.test.ts
+++ b/tests/cfg/cfg.test.ts
@@ -1,3 +1,22 @@
+/*
+ * SonarTS
+ * Copyright (C) 2017-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 import * as tslint from "tslint";
 import { ControlFlowGraph } from "../../src/cfg/cfg";
 import toVis, { VisData } from "../../src/tools/cfg_viewer/transformer";

--- a/tests/cfg/cfg_block.test.ts
+++ b/tests/cfg/cfg_block.test.ts
@@ -1,3 +1,22 @@
+/*
+ * SonarTS
+ * Copyright (C) 2017-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 import * as ts from "typescript";
 import { CfgBlock, CfgBlockWithPredecessors, CfgGenericBlock } from "../../src/cfg/cfg";
 

--- a/tests/tools/cfg_viewer/transformer.test.ts
+++ b/tests/tools/cfg_viewer/transformer.test.ts
@@ -1,3 +1,22 @@
+/*
+ * SonarTS
+ * Copyright (C) 2017-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 import * as tslint from "tslint";
 import * as ts from "typescript";
 import { DataSet } from "vis";


### PR DESCRIPTION
Test files are checked only if the 'src/**/*.ts' is removed, for some reason