### PR TITLE
update no-self-assignment (S1656) to raise issues on "a = a.reverse()"

### DIFF
--- a/tests/rules/noSelfAssignmentRule/noSelfAssignmentRule.lint.ts
+++ b/tests/rules/noSelfAssignmentRule/noSelfAssignmentRule.lint.ts
@@ -27,3 +27,11 @@ x = x + x;
 
 while (x = x) {}
 //     ^^^^^       {{Remove or correct this useless self-assignment.}}
+
+let arr = [];
+
+  arr = arr.reverse();
+//^^^^^^^^^^^^^^^^^^^  {{Remove or correct this useless self-assignment.}}
+
+let notArray: any;
+notArray = notArray.reverse();

--- a/tests/ruling/snapshots/no-self-assignment
+++ b/tests/ruling/snapshots/no-self-assignment
@@ -1,1 +1,6 @@
-
+src/postgraphql/src/postgres/inventory/paginator/PgPaginatorOrderingAttributes.ts: 111
+src/vscode/build/lib/nls.ts: 355
+src/vscode/src/vs/base/common/async.ts: 377
+src/vscode/src/vs/editor/contrib/linesOperations/common/sortLinesCommand.ts: 80
+src/vscode/src/vs/editor/contrib/smartSelect/common/tokenSelectionSupport.ts: 66
+src/vscode/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts: 287


### PR DESCRIPTION
fixes #136 