### PR TITLE
Add comment describing toSonarLine

### DIFF
--- a/sonarts-core/src/runner/sonar-utils.ts
+++ b/sonarts-core/src/runner/sonar-utils.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+// SonarQube's line indexing starts from 1, while TypeScript is 0 based.
 export function toSonarLine(line: number) {
   return line + 1;
 }


### PR DESCRIPTION
The toSonarLine method is a bit confusing without documentation. Adding
a line of comment to describe it's behaviour. SonarQube is indexing file
lines from 1, whily TypeScript is indexing from 0.
Closes #260 