### PR TITLE
Fix typo in README testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,19 +114,19 @@ to enable TypeScript support.
 
 To run unit tests:
 ```
-cd sonarts-code
+cd sonarts-core
 yarn test
 ```
 
 To run unit tests in watch mode:
 ```
-cd sonarts-code
+cd sonarts-core
 yarn test -- --watch
 ```
 
 And finally to run unit tests with coverage:
 ```
-cd sonarts-code
+cd sonarts-core
 yarn test -- --coverage
 ```
 When you run tests with coverage, the `coverage/` directory will be created at the root. You can


### PR DESCRIPTION
The suggested path for testing was incorrectly sonarts-code, the actual
folder is sonarts-core. Probably just a typo, fixing.
Closes #262 