### PR TITLE
Correct scm data to remove "-Plugin"

### DIFF
--- a/sonarts-sq-plugin/pom.xml
+++ b/sonarts-sq-plugin/pom.xml
@@ -53,9 +53,9 @@
   </modules>
 
   <scm>
-    <connection>scm:git:git@github.com:SonarSource/SonarTS-Plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:SonarSource/SonarTS-Plugin.git</developerConnection>
-    <url>https://github.com/SonarSource/SonarTS-Plugin</url>
+    <connection>scm:git:git@github.com:SonarSource/SonarTS.git</connection>
+    <developerConnection>scm:git:git@github.com:SonarSource/SonarTS.git</developerConnection>
+    <url>https://github.com/SonarSource/SonarTS</url>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>


### PR DESCRIPTION
Current information leads to incorrect data in Marketplace and analyzer documentation (generated header)

