### PR TITLE
Support SQ 7.2 in integration tests

### DIFF
--- a/.cix.yml
+++ b/.cix.yml
@@ -10,7 +10,7 @@ TEST:
 SQ_VERSION:
   - DEV
   - LATEST_RELEASE
-  - LTS
+  - LATEST_RELEASE[6.7]
 
 exclude:
 
@@ -29,7 +29,7 @@ exclude:
     SQ_VERSION: DEV
 
   - SLAVE: windows
-    SQ_VERSION: LTS
+    SQ_VERSION: LATEST_RELEASE[6.7]
 
 
     
@@ -37,7 +37,7 @@ exclude:
     SQ_VERSION: DEV
     
   - SLAVE: multicpu
-    SQ_VERSION: LTS
+    SQ_VERSION: LATEST_RELEASE[6.7]
 
   - SLAVE: multicpu
     TEST: ci

--- a/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/EslintExternalReportTest.java
+++ b/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/EslintExternalReportTest.java
@@ -60,6 +60,6 @@ public class EslintExternalReportTest {
   }
 
   public static boolean sqSupportsExternalIssues() {
-    return orchestrator.getConfiguration().getSonarVersion().isGreaterThanOrEquals("7.2");
+    return orchestrator.getServer().version().isGreaterThanOrEquals(7, 2);
   }
 }

--- a/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/Tests.java
+++ b/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/Tests.java
@@ -39,7 +39,6 @@ import org.sonarqube.ws.client.WsClientFactories;
 import org.sonarqube.ws.client.measures.ComponentRequest;
 
 import static java.util.Collections.singletonList;
-import static java.util.Objects.requireNonNull;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -65,7 +64,7 @@ public class Tests {
 
   static {
     OrchestratorBuilder orchestratorBuilder = Orchestrator.builderEnv()
-      .setSonarVersion(requireNonNull(System.getProperty("sonar.runtimeVersion"), "Please set system property sonar.runtimeVersion"))
+      .setSonarVersion(System.getProperty("sonar.runtimeVersion", "7.2.0.13185")) // FIXME update when 7.2 released
       .addPlugin(PLUGIN_LOCATION);
 
     File profilesDir = new File("src/test/resources/profiles/");

--- a/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/Tests.java
+++ b/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/Tests.java
@@ -64,7 +64,7 @@ public class Tests {
 
   static {
     OrchestratorBuilder orchestratorBuilder = Orchestrator.builderEnv()
-      .setSonarVersion(System.getProperty("sonar.runtimeVersion", "7.2.0.13185")) // FIXME update when 7.2 released
+      .setSonarVersion(System.getProperty("sonar.runtimeVersion", "7.2-RC1"))
       .addPlugin(PLUGIN_LOCATION);
 
     File profilesDir = new File("src/test/resources/profiles/");

--- a/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/Tests.java
+++ b/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/Tests.java
@@ -39,6 +39,7 @@ import org.sonarqube.ws.client.WsClientFactories;
 import org.sonarqube.ws.client.measures.ComponentRequest;
 
 import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -63,8 +64,9 @@ public class Tests {
   public static final Orchestrator ORCHESTRATOR;
 
   static {
-    OrchestratorBuilder orchestratorBuilder = Orchestrator.builderEnv();
-    orchestratorBuilder.addPlugin(PLUGIN_LOCATION);
+    OrchestratorBuilder orchestratorBuilder = Orchestrator.builderEnv()
+      .setSonarVersion(requireNonNull(System.getProperty("sonar.runtimeVersion"), "Please set system property sonar.runtimeVersion"))
+      .addPlugin(PLUGIN_LOCATION);
 
     File profilesDir = new File("src/test/resources/profiles/");
     for (File file : profilesDir.listFiles()) {

--- a/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/TslintExternalReportTest.java
+++ b/sonarts-sq-plugin/its/plugin/src/test/java/org/sonar/typescript/its/TslintExternalReportTest.java
@@ -61,6 +61,6 @@ public class TslintExternalReportTest {
   }
 
   public static boolean sqSupportsExternalIssues() {
-    return orchestrator.getConfiguration().getSonarVersion().isGreaterThanOrEquals("7.2");
+    return orchestrator.getServer().version().isGreaterThanOrEquals(7, 2);
   }
 }

--- a/sonarts-sq-plugin/pom.xml
+++ b/sonarts-sq-plugin/pom.xml
@@ -77,7 +77,7 @@
     <slf4j.version>1.7.21</slf4j.version>
     <sonar.version>7.2.0.12767</sonar.version>
     <sonar.min.version>6.7</sonar.min.version>
-    <sonar-orchestrator.version>3.14.0.887</sonar-orchestrator.version>
+    <sonar-orchestrator.version>3.19.0.1641</sonar-orchestrator.version>
     <sonarlint.version>3.1.0.1376</sonarlint.version>
     <gson.version>2.6.2</gson.version>
     <commons-io.version>2.5</commons-io.version>

--- a/sonarts-sq-plugin/pom.xml
+++ b/sonarts-sq-plugin/pom.xml
@@ -75,7 +75,7 @@
     <junit.version>4.12</junit.version>
     <logback.version>1.0.13</logback.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <sonar.version>7.2.0.12767</sonar.version>
+    <sonar.version>7.2-RC1</sonar.version>
     <sonar.min.version>6.7</sonar.min.version>
     <sonar-orchestrator.version>3.19.0.1641</sonar-orchestrator.version>
     <sonarlint.version>3.1.0.1376</sonarlint.version>


### PR DESCRIPTION
Upgrading Orchestrator to v3.19 allows to support SonarQube 7.2, which plugins are bundled in a new directory.