### PR TITLE
Fix compatibility with TS 2.2: stop using Node.forEachChild

### DIFF
--- a/sonarts-core/src/rules/noReturnTypeAnyRule.ts
+++ b/sonarts-core/src/rules/noReturnTypeAnyRule.ts
@@ -63,7 +63,7 @@ class Visitor extends TypedSonarRuleVisitor {
       if (isReturnStatement(node)) {
         returns.push(node);
       } else if (!isFunctionLikeDeclaration(node)) {
-        node.forEachChild(visitNode);
+        ts.forEachChild(node, visitNode);
       }
     };
     visitNode(body);


### PR DESCRIPTION
Fixes #735 
