### PR TITLE
Fix Node version check to be (more) semver compat

### DIFF
--- a/sonarts-sq-plugin/sonar-typescript-plugin/src/main/java/org/sonar/plugin/typescript/ExternalTypescriptSensor.java
+++ b/sonarts-sq-plugin/sonar-typescript-plugin/src/main/java/org/sonar/plugin/typescript/ExternalTypescriptSensor.java
@@ -165,7 +165,7 @@ public class ExternalTypescriptSensor implements Sensor {
 
     Pattern versionPattern = Pattern.compile("v?(\\d+)\\.\\d+\\.\\d+");
     Matcher versionMatcher = versionPattern.matcher(version);
-    if (versionMatcher.matches()) {
+    if (versionMatcher.lookingAt()) {
       int major = Integer.parseInt(versionMatcher.group(1));
       if (major < MIN_NODE_VERSION) {
         String message = String.format("Only Node.js v%s or later is supported, got %s. %s", MIN_NODE_VERSION, version, messageSuffix);


### PR DESCRIPTION
The current Node version check uses Java `Matcher.matches()` which will
only return `true` if the entire string matches.  This prevents
distributions from attaching `semver`-legal build identifiers to the
Node version number.  Using `lookingAt()` instead only attempts to match
against the beginning of the string.

Per semver/semver:

> 9. A pre-release version MAY be denoted by appending a hyphen and a
> series of dot separated identifiers immediately following the patch
> version.
>
> 10. Build metadata MAY be denoted by appending a plus sign and a
> series of dot separated identifiers immediately following the patch
> or pre-release version.

A version string even as simple as "v10.9.0+0" causes the current
version check to fail.