### PR TITLE
Fix typo in no-collapsible-if docs

### DIFF
--- a/sonarts-core/docs/rules/no-collapsible-if.md
+++ b/sonarts-core/docs/rules/no-collapsible-if.md
@@ -14,7 +14,7 @@ if (x != undefined) {
 ## Compliant Solution
 
 ```typescript
-if (x != undefined &amp;&amp; y === 2) {
+if (x != undefined && y === 2) {
   // ...
 }
 ```


### PR DESCRIPTION
The ampersands were unnecesarily HTML escaped.
