### PR TITLE
Add '--save-dev' to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Node.js (>=6.x).
 * Install `tslint-sonarts`
 
 ```sh
-npm install tslint-sonarts      # install in your project
-npm install tslint-sonarts -g   # or install globally
+npm install tslint-sonarts --save-dev   # install in your project
+npm install tslint-sonarts -g           # or install globally
 ```
 
 * Add `tslint-sonarts` to your `tslint.json` `extends` property:


### PR DESCRIPTION
You almost always want tslint and company to be in devDependencies.


