### PR TITLE
Improve logging for lcov parser when coverage report is inconsistent

### DIFF
--- a/sonarts-sq-plugin/sonar-typescript-plugin/src/main/java/org/sonar/plugin/typescript/lcov/LCOVCoverageSensor.java
+++ b/sonarts-sq-plugin/sonar-typescript-plugin/src/main/java/org/sonar/plugin/typescript/lcov/LCOVCoverageSensor.java
@@ -76,6 +76,11 @@ public class LCOVCoverageSensor implements Sensor {
           "Could not resolve %d file paths in %s, first unresolved path: %s",
           unresolvedPaths.size(), lcovReportFiles, unresolvedPaths.get(0)));
     }
+
+    int inconsistenciesNumber = parser.inconsistenciesNumber();
+    if (inconsistenciesNumber > 0) {
+      LOG.warn("Found {} inconsistencies in coverage report. Re-run analyse in debug mode to see details.", inconsistenciesNumber);
+    }
   }
 
   /**

--- a/sonarts-sq-plugin/sonar-typescript-plugin/src/main/java/org/sonar/plugin/typescript/lcov/LCOVParser.java
+++ b/sonarts-sq-plugin/sonar-typescript-plugin/src/main/java/org/sonar/plugin/typescript/lcov/LCOVParser.java
@@ -49,6 +49,7 @@ public final class LCOVParser {
 
   private final SensorContext context;
   private final List<String> unresolvedPaths = new ArrayList<>();
+  private int inconsistenciesCounter = 0;
 
   private static final Logger LOG = Loggers.get(LCOVParser.class);
 
@@ -72,6 +73,10 @@ public final class LCOVParser {
 
   List<String> unresolvedPaths() {
     return unresolvedPaths;
+  }
+
+  int inconsistenciesNumber() {
+    return inconsistenciesCounter;
   }
 
   private void parse(List<String> lines) {
@@ -101,7 +106,7 @@ public final class LCOVParser {
     }
   }
 
-  private static void parseBranchCoverage(FileData fileData, int reportLineNum, String line) {
+  private void parseBranchCoverage(FileData fileData, int reportLineNum, String line) {
     try {
       // BRDA:<line number>,<block number>,<branch number>,<taken>
       String[] tokens = line.substring(BRDA.length()).trim().split(",");
@@ -115,7 +120,7 @@ public final class LCOVParser {
     }
   }
 
-  private static void parseLineCoverage(FileData fileData, int reportLineNum, String line) {
+  private void parseLineCoverage(FileData fileData, int reportLineNum, String line) {
     try {
       // DA:<line number>,<execution count>[,<checksum>]
       String execution = line.substring(DA.length());
@@ -128,8 +133,9 @@ public final class LCOVParser {
     }
   }
 
-  private static void logWrongDataWarning(String dataType, int reportLineNum, Exception e) {
-    LOG.warn(String.format("Problem during processing LCOV report: can't save %s data for line %s of coverage report file (%s).", dataType, reportLineNum, e.toString()));
+  private void logWrongDataWarning(String dataType, int reportLineNum, Exception e) {
+    LOG.debug(String.format("Problem during processing LCOV report: can't save %s data for line %s of coverage report file (%s).", dataType, reportLineNum, e.toString()));
+    inconsistenciesCounter++;
   }
 
   @CheckForNull

--- a/sonarts-sq-plugin/sonar-typescript-plugin/src/test/resources/coverage/reports/wrong_data_report.lcov
+++ b/sonarts-sq-plugin/sonar-typescript-plugin/src/test/resources/coverage/reports/wrong_data_report.lcov
@@ -1,0 +1,9 @@
+TN:
+SF:file1.ts
+DA:1.,2
+DA:1
+DA:2,1
+BRDA:2,1,0
+BRDA:2,1,1,1
+BRDA:2,2,0,1
+end_of_record

--- a/sonarts-sq-plugin/sonar-typescript-plugin/src/test/resources/coverage/reports/wrong_line_report.lcov
+++ b/sonarts-sq-plugin/sonar-typescript-plugin/src/test/resources/coverage/reports/wrong_line_report.lcov
@@ -1,0 +1,9 @@
+TN:
+SF:file1.ts
+DA:0,1
+DA:2,1
+BRDA:2,1,0,0
+BRDA:2,1,1,0
+BRDA:2,2,0,1
+BRDA:102,2,1,0
+end_of_record


### PR DESCRIPTION
Made consistent with SonarJS - github.com/SonarSource/SonarJS/pull/1018

Fixes #776
