### PR TITLE
Fix a small error in S2933 example

### DIFF
--- a/sonarts-sq-plugin/sonar-typescript-plugin/src/main/resources/org/sonar/l10n/typescript/rules/typescript/S2933.html
+++ b/sonarts-sq-plugin/sonar-typescript-plugin/src/main/resources/org/sonar/l10n/typescript/rules/typescript/S2933.html
@@ -14,7 +14,7 @@ class Person {
 <h2>Compliant Solution</h2>
 <pre>
 class Person {
-  private readonly _birthYear: number;  // Noncompliant
+  private readonly _birthYear: number;
   constructor(birthYear: number) {
     this._birthYear = birthYear;
   }


### PR DESCRIPTION
Fixes a small error in the S2933 docs. Currently, the compliant version of the code includes the "// Noncompliant" comment. Probably a copy/paste error.
